### PR TITLE
Add Dependabot and Security Scanning for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "friday"
+
+  # Updates the dependencies of the GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "friday"

--- a/.github/workflows/create_chango_fragment.yml
+++ b/.github/workflows/create_chango_fragment.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Create the new fragment
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: ./
 

--- a/.github/workflows/doc_build_test.yml
+++ b/.github/workflows/doc_build_test.yml
@@ -14,9 +14,11 @@ jobs:
     name: test-sphinx-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.12
           cache: 'pip'

--- a/.github/workflows/gha_security.yml
+++ b/.github/workflows/gha_security.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  zizmor:
+    name: Security Analysis with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+      - name: Run zizmor
+        run: uvx zizmor --persona=pedantic --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/type_completeness_test.yml
+++ b/.github/workflows/type_completeness_test.yml
@@ -14,7 +14,7 @@ jobs:
     name:   test-type-completeness
     runs-on: ubuntu-latest
     steps:
-      - uses: Bibo-Joshi/pyright-type-completeness@1.0.0
+      - uses: Bibo-Joshi/pyright-type-completeness@c85a67ff3c66f51dcbb2d06bfcf4fe83a57d69cc # v1.0.1
         with:
           package-name: chango
           python-version: 3.12

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,10 +21,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: False
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -44,14 +46,14 @@ jobs:
 
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2.3
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         if: always()  # always run, even if tests fail
         with:
           paths: |
             .test_junit.xml
 
       - name: Submit coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e  # v5.1.1
         with:
           env_vars: OS,PYTHON
           name: ${{ matrix.os }}-${{ matrix.python-version }}
@@ -59,7 +61,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@9739113ad922ea0a9abb4b2c0f8bf6a4aa8ef820 # v1.0.1
         if: ${{ !cancelled() }}
         with:
           files: .test_junit.xml

--- a/action.yml
+++ b/action.yml
@@ -21,13 +21,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.head_ref }}
 
     - name: Set up Python
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -39,7 +39,7 @@ runs:
 
     - name: Create chango fragment
       id: create-chango-fragment
-      uses: jannekem/run-python-script-action@v1
+      uses: jannekem/run-python-script-action@bbfca66c612a28f3eeca0ae40e1f810265e2ea68 # v1.7
       with:
         script: |
           from chango.config import get_chango_instance
@@ -55,6 +55,6 @@ runs:
     - name: Commit and Push
       id: commit-and-push
       if: ${{ inputs.commit-and-push == 'true' }}
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
       with:
         commit_message: "Add chango fragment for PR #${{ github.event.pull_request.number }}"

--- a/changes/unreleased/0037.hfNakUZfHjCbfW2bKcYy8s.rst
+++ b/changes/unreleased/0037.hfNakUZfHjCbfW2bKcYy8s.rst
@@ -1,0 +1,1 @@
+Add Dependabot and Security Scanning for GitHub Actions (`#37 <https://github.com/Bibo-Joshi/chango/pull/37>`_)

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -33,8 +33,8 @@ You can configure it for example as follows:
         name: create-chango-fragment
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
-          - uses: Bibo-Joshi/chango@main
+          - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          - uses: Bibo-Joshi/chango@<sha-of-latest-release>
             with:
               # Optional: Specify a Python version to use
               python-version: '3.13'


### PR DESCRIPTION
Inspired by 

* https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/
* https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection
* https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/


Edit: 

1. I decided to set up a workflow for this instead of using pre-commit because
    1. this enables to use the [online audits](https://woodruffw.github.io/zizmor/usage/#operating-modes)
    2. workflows are rarely updated so that adding a pre-commit hook for that seems like an unnecessary additional install step on local end to me
2. As far as I see, dependabot is able to update actions that are pinned with a sha